### PR TITLE
Add instance variable to define a name of test generated's class

### DIFF
--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,9 +48,13 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 |
-_var0 := RTGrapher new.
-_var1 := _var0 homogenizeMinAndMax.
+	| _var0 _var1 _var2 _var3 _var4 _var5 |
+_var0 := SFoo new.
+_var1 := _var0 returnCollection.
+_var2 := _var0 return: _var1.
+_var3 := _var0 return: _var2.
+_var4 := _var0 initialize.
+_var5 := _var0 return: _var2.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/STestCaseFactory.class.st
+++ b/src/SmallSuiteGenerator/STestCaseFactory.class.st
@@ -12,7 +12,8 @@ Class {
 		'outputPackageName',
 		'fitness',
 		'numberOfIterations',
-		'profiler'
+		'profiler',
+		'targetTestClassName'
 	],
 	#classInstVars : [
 		'instance'
@@ -65,7 +66,7 @@ STestCaseFactory >> engineDefault [
 { #category : #actions }
 STestCaseFactory >> export: aTestCase with: aSelector [
 	| aClassName class |
-	aClassName := ('GA' , self targetClassName , 'Test') asSymbol.
+	aClassName := targetTestClassName ifNil: [('GA' , self targetClassName , 'Test') asSymbol].
 	class := SConfiguration lookUpClass: aClassName.
 	class
 		ifNil: [ class := SConfiguration
@@ -217,6 +218,11 @@ STestCaseFactory >> targetPackageRegex [
 { #category : #accessing }
 STestCaseFactory >> targetPackageRegex: anObject [
 	targetPackageRegex := anObject
+]
+
+{ #category : #actions }
+STestCaseFactory >> targetTestClassName: aString [
+	targetTestClassName := aString asSymbol 
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Fixes #46 
Now you can specify by this way:
```
STestCaseFactoryPharo new
    typeInfo: typeInfo;
    fitness: SStatementCoverage new;
    targetClassName:#SFoo;
    targetPackageRegex:'SmallSuiteGenerator-Scenario';
    outputPackageName:'SmallSuiteGenerator-Tests-Generated';
     numberOfGenerations: 20;
    numberOfStatements: 10;
	targetTestClassName: 'MyTEST';
    createTestCases;
    yourself.
```