### PR TITLE
Add Meaningful variable names

### DIFF
--- a/src/SmallSuiteGenerator/SFactoryMessage.class.st
+++ b/src/SmallSuiteGenerator/SFactoryMessage.class.st
@@ -93,6 +93,13 @@ SFactoryMessage >> isFactoryMessage [
 	^ true
 ]
 
+{ #category : #printing }
+SFactoryMessage >> printOn: aStream [
+	receiver returnType asClass printOn: aStream.
+	aStream	nextPut: Character space.
+	self printSelectors: aStream
+]
+
 { #category : #accessing }
 SFactoryMessage >> referenceTo: aClassName [
 	^ receiver referenceTo: aClassName

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,9 +48,9 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 |
-_var0 := RTGrapher new.
-_var1 := _var0 homogenizeMinAndMax.
+	| _aSFoo0 _anOrderedCollection1 |
+_aSFoo0 := SFoo new.
+_anOrderedCollection1 := _aSFoo0 returnCollection.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/SVariable.class.st
+++ b/src/SmallSuiteGenerator/SVariable.class.st
@@ -114,6 +114,12 @@ SVariable >> replaceExpression: anExpression by: newExpression [
 ]
 
 { #category : #accessing }
+SVariable >> returnType: anObject [
+	varName := anObject first isVowel ifTrue: ['_an', anObject ] ifFalse: ['_a', anObject ].
+	returnType := anObject.
+]
+
+{ #category : #accessing }
 SVariable >> varName [
 	^ varName
 ]


### PR DESCRIPTION
Fixes #16 

Now generate test like:
```
test30
  "Fitness: 
block-coverage: 4.762
"
  "This test covers: 
block-coverage
SFoo:4.762%
"
  | _aSFoo0 _anOrderedCollection1 _aDictionary2 |
  _aSFoo0 := SFoo new.
  _anOrderedCollection1 := _aSFoo0 returnCollection.
  _aDictionary2 := _aSFoo0 return: _anOrderedCollection1.
  self assert: _anOrderedCollection1 equals: _aDictionary2.
  self assert: _aSFoo0 score equals: 0.
  self assert: _anOrderedCollection1 printString equals: 'an OrderedCollection()'.
  self assert: _aDictionary2 printString equals: 'an OrderedCollection()'
```