### PR TITLE
Updates to improve fitness evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ You can load SmallSuiteGenerator into VW image with the next steps:
 The first step is to define the code block that will be instrumented to get the typeInfo. Define package's regular expression pattern also.
 
 ``` Smalltalk
-| typeInfo |
-typeInfo := STypeInfo asTypeInfo: (
-		SSTypeCollector profile:[ 
+| typeInfo aBlock |
+aBlock := [ 
 			(SSTeacher name: 'Ann' with: 50)
 			nickname;
 			canRegister: ((SConference price: 50) offerPrice: 50);
 			idTeacher;
-			yearsWorkExperience ] onPackagesMatching: 'SmallSuiteGenerator-Scenario').
+			yearsWorkExperience ].
+typeInfo := STypeInfo asTypeInfo: (
+		SSTypeCollector profile: aBlock onPackagesMatching: 'SmallSuiteGenerator-Scenario').
 ```
 
 The second step is to configure the class `STestCaseFactory`.
@@ -62,6 +63,7 @@ STestCaseFactoryPharo new
     outputPackageName: 'SmallSuiteGenerator-Tests-Generated';
     numberOfGenerations: 20;
     numberOfStatements: 3;
+    seedBlock: aBlock;
     createTestCases;
     yourself.
 ```
@@ -77,10 +79,20 @@ To watch the evolution of fitness function call `visualize` method.
 
 After to execute this script the testCases will be generated with the higher fitness of the population. In the output package name specified you can find the generated testCases. Usually the last enumerated testCases have the highests fitness.
 
-Additionally to the described configurations, you can configure some parameters before to generate test cases, e.g:
+### Advanced settings
+
+All this settings should be done before generate test cases
+
+- Change population size.
 
 ```Smalltalk 
 populationSize: 30.
+```
+
+- Sometimes the number variables is limited, to fix this problem you can change the default generations testing with variables by using a dictionary.
+
+```Smalltalk 
+asDict: true.
 ```
 
 ## Install SpyLite

--- a/src/BaselineOfSmallSuiteGenerator/BaselineOfSmallSuiteGenerator.class.st
+++ b/src/BaselineOfSmallSuiteGenerator/BaselineOfSmallSuiteGenerator.class.st
@@ -13,6 +13,9 @@ BaselineOfSmallSuiteGenerator >> baseline: spec [
 				baseline: 'SpyLite'
 				with: [ spec repository: 'github://andreina-covi/SpyLite:master/src' ].
 				spec
+				baseline: 'RoelTyper'
+				with: [ spec repository: 'github://RMODINRIA/RoelTyper:master/src' ].
+				spec
 				baseline: 'Roassal2'
 				with: [ spec repository: 'github://ObjectProfile/Roassal2/src' ].
 			spec

--- a/src/BaselineOfSmallSuiteGenerator/BaselineOfSmallSuiteGenerator.class.st
+++ b/src/BaselineOfSmallSuiteGenerator/BaselineOfSmallSuiteGenerator.class.st
@@ -13,8 +13,8 @@ BaselineOfSmallSuiteGenerator >> baseline: spec [
 				baseline: 'SpyLite'
 				with: [ spec repository: 'github://andreina-covi/SpyLite:master/src' ].
 				spec
-				baseline: 'RoelTyper'
-				with: [ spec repository: 'github://RMODINRIA/RoelTyper:master/src' ].
+    			baseline: 'RoelTyper'
+    			with: [ spec repository: 'github://RMODINRIA/RoelTyper:v1.x.x/src' ].
 				spec
 				baseline: 'Roassal2'
 				with: [ spec repository: 'github://ObjectProfile/Roassal2/src' ].
@@ -32,7 +32,7 @@ BaselineOfSmallSuiteGenerator >> baseline: spec [
 				with: [ spec repository: 'github://andreina-covi/SparkCircleCopy:master/src' ].
 			spec
 				package: 'SmallSuiteGenerator'
-					with: [ spec requires: #('SpyLite' 'MuTalk' 'NeoCSV' 'TinyLogger') ];
+					with: [ spec requires: #('RoelTyper' 'SpyLite' 'MuTalk' 'NeoCSV' 'TinyLogger') ];
 				package: 'SmallSuiteGenerator-Scenario';
 				package: 'SmallSuiteGenerator-Scenario2';
 				package: 'SmallSuiteGenerator-Visualization' with: [ spec requires: #('Roassal2' 'SparkCircleCopy') ];

--- a/src/SmallSuiteGenerator-Tests/STypeInfoTest.class.st
+++ b/src/SmallSuiteGenerator-Tests/STypeInfoTest.class.st
@@ -41,7 +41,7 @@ STypeInfoTest >> testAsTypeInfoSConferenceOnPackagesMatching [
 		assert:
 			((messages flatCollect: [ :aMessage | aMessage receiver types ])
 				allSatisfy: [ :aType | aType = (self nameOf: SConference) ]).
-	self assert: (typeInfo messagesFrom: (self nameOf: SEvent)) isEmpty.
+	self assert: ((typeInfo messagesFrom: (self nameOf: SEvent)) allSatisfy: #isUnary).
 	self assert: (typeInfo messagesFrom: (self nameOf: SParty)) isEmpty.
 	messages := typeInfo factoryMessagesFrom: (self nameOf:  SConference).
 	self
@@ -66,15 +66,15 @@ STypeInfoTest >> testAsTypeInfoSEventOnPackagesMatching [
 		onPackagesMatching: 'SmallSuiteGenerator-Scenario').
 	self
 		assert: (typeInfo types at: classNameSEvent) methodTypes size
-		equals: 2.
+		equals: 4.
 	self
 		assert: (typeInfo types at: classNameSEvent) classMethodTypes isEmpty.
 	self
 		assert: (typeInfo types at: classNameSConference) methodTypes size
-		equals: 3.
+		equals: 5.
 	self
 		assert: (typeInfo types at: classNameSConference) classMethodTypes isEmpty.
-	self assert: (typeInfo types at: classNameSParty) methodTypes isEmpty.
+	self assert: ((typeInfo types at: classNameSParty) methodTypes allSatisfy: #isUnary).
 	self
 		assert: (typeInfo types at: classNameSParty) classMethodTypes isEmpty.
 	messages := typeInfo messagesFrom: classNameSConference.
@@ -100,6 +100,7 @@ STypeInfoTest >> testAsTypeInfoSEventOnPackagesMatching [
 		assertCollection: typeInfo scalars keys
 		hasSameElements:
 			(Array
+				with: (self nameOf: nil class)
 				with: classNameSStudent
 				with: classNameSmallInteger
 				with: (self nameOf: False)
@@ -192,7 +193,7 @@ STypeInfoTest >> testAsTypeInfoSFooOnClass [
 	typeInfo := STypeInfo asTypeInfo: profile.
 	self
 		assert: (typeInfo types at: classNameSFoo) methodTypes size
-		equals: 2.
+		equals: 7.
 	self
 		assert: (typeInfo types at: classNameSFoo) classMethodTypes isEmpty.
 	self
@@ -207,7 +208,7 @@ STypeInfoTest >> testAsTypeInfoSFooOnClass [
 		hasSameElements: (Array with: (self nameOf: OrderedCollection class)).
 	self
 		assertCollection: ((typeInfo messagesFrom: classNameSFoo) collect: #selector)
-		hasSameElements: #(#initialize #return:)
+		hasSameElements: #(#returnFloat #returnCollection #initialize #returnNum #returnString #return:)
 ]
 
 { #category : #tests }
@@ -220,7 +221,7 @@ STypeInfoTest >> testAsTypeInfoSFooWithNil [
 	typeInfo := STypeInfo asTypeInfo: profile.
 	self
 		assert: (typeInfo types at: classNameSFoo) methodTypes size
-		equals: 2.
+		equals: 7.
 	self
 		assert: (typeInfo types at: classNameSFoo) classMethodTypes isEmpty.
 	self
@@ -235,7 +236,7 @@ STypeInfoTest >> testAsTypeInfoSFooWithNil [
 		hasSameElements: (Array with: (self nameOf: UndefinedObject)).
 	self
 		assertCollection: ((typeInfo messagesFrom: classNameSFoo) collect: #selector)
-		hasSameElements: #(#initialize #return:)
+		hasSameElements: #(#returnFloat #returnCollection #initialize #returnNum #returnString #return:)
 ]
 
 { #category : #tests }
@@ -304,7 +305,7 @@ STypeInfoTest >> testAsTypeInfoScalars [
 		onPackagesMatching: 'SmallSuiteGenerator-Scenario').
 	self
 		assertCollection: (typeInfo scalars values flatCollect: [ :val | val ])
-		hasSameElements: #(95 0 100).
+		hasSameElements: #(95 0 100 nil).
 	typeInfo := STypeInfo asTypeInfo: (SSTypeCollector
 		profile: [ SFoo new
 				returnCollection;
@@ -316,6 +317,7 @@ STypeInfoTest >> testAsTypeInfoScalars [
 		assertCollection: typeInfo scalars associations
 		hasSameElements:
 			(Array
+				with: (self nameOf: nil class) -> #(nil)
 				with: (self nameOf: SmallInteger) -> #(0 4)
 				with: (self nameOf: OrderedCollection) -> (Array with: OrderedCollection new)
 				with: (self nameOf: ByteString) -> #('Hello')

--- a/src/SmallSuiteGenerator-Tests/STypeInfoTest.class.st
+++ b/src/SmallSuiteGenerator-Tests/STypeInfoTest.class.st
@@ -100,7 +100,7 @@ STypeInfoTest >> testAsTypeInfoSEventOnPackagesMatching [
 		assertCollection: typeInfo scalars keys
 		hasSameElements:
 			(Array
-				with: (self nameOf: nil class)
+				with: (self nameOf: (SUndefinedObject basicNew) class)
 				with: classNameSStudent
 				with: classNameSmallInteger
 				with: (self nameOf: False)
@@ -317,7 +317,7 @@ STypeInfoTest >> testAsTypeInfoScalars [
 		assertCollection: typeInfo scalars associations
 		hasSameElements:
 			(Array
-				with: (self nameOf: nil class) -> #(nil)
+				with: (self nameOf: (SUndefinedObject basicNew) class) -> #(nil)
 				with: (self nameOf: SmallInteger) -> #(0 4)
 				with: (self nameOf: OrderedCollection) -> (Array with: OrderedCollection new)
 				with: (self nameOf: ByteString) -> #('Hello')

--- a/src/SmallSuiteGenerator-Tests/SmallTypeCollectorTest.class.st
+++ b/src/SmallSuiteGenerator-Tests/SmallTypeCollectorTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #SmallTypeCollectorTest,
+	#superclass : #TestCase,
+	#category : #'SmallSuiteGenerator-Tests-SmallType'
+}
+
+{ #category : #tests }
+SmallTypeCollectorTest >> testAnInteger [
+	self assert:#Integer equals: (self typeFor:'anInteger').
+]
+
+{ #category : #tests }
+SmallTypeCollectorTest >> testInteger [
+	self assert:#Integer equals: (self typeFor:'integer').
+]
+
+{ #category : #tests }
+SmallTypeCollectorTest >> typeFor: aName [
+	^ SmallTypeCollector new typeFor: aName.
+]

--- a/src/SmallSuiteGenerator/ByteSymbol.extension.st
+++ b/src/SmallSuiteGenerator/ByteSymbol.extension.st
@@ -1,17 +1,17 @@
-Extension { #name : #String }
+Extension { #name : #ByteSymbol }
 
 { #category : #'*SmallSuiteGenerator' }
-String >> mutateToChange [
+ByteSymbol >> mutateToChange [
 	| interval stringCopy randomGenerator |
 	"correct bug to some characters form the string correctly, e.g: $-> problem in a string"
 	randomGenerator := SPlatform newRandomGenerator.
-	interval := (41 to: 127) asArray.
+	interval := Character alphabet , $_ asString.
 	stringCopy := self
 		ifEmpty: [ '' ]
 		ifNotEmpty: [ self copyFrom: 1 to: self size - 1 ].
-	^ ((Character value: (randomGenerator selectAtRandom: interval))
+	^ ((randomGenerator selectAtRandom: interval)
 		asString , stringCopy
 		,
-			(Character value: (randomGenerator selectAtRandom: interval)) asString)
-		asString
+			(randomGenerator selectAtRandom: interval) asString)
+		asSymbol
 ]

--- a/src/SmallSuiteGenerator/SAssignment.class.st
+++ b/src/SmallSuiteGenerator/SAssignment.class.st
@@ -30,6 +30,7 @@ SAssignment class >> name: aVariable value: anExpression [
 		variable:  aVariable;
 		value: anExpression;
 		returnType: anExpression returnType;
+		needsBeFixed: anExpression needsBeFixed;
 		yourself
 ]
 

--- a/src/SmallSuiteGenerator/SAssignment.class.st
+++ b/src/SmallSuiteGenerator/SAssignment.class.st
@@ -50,6 +50,14 @@ SAssignment >> copy [
 	^ copy
 ]
 
+{ #category : #fixing }
+SAssignment >> fixWith: anObject in: aTestCase [
+	value fixWith: anObject in: aTestCase.
+	returnType := value returnType.
+	variable returnType: value returnType.
+	needsBeFixed := value needsBeFixed 
+]
+
 { #category : #comparing }
 SAssignment >> hash [
 	^ super hash bitXor: (variable hash bitXor: value hash)

--- a/src/SmallSuiteGenerator/SExpression.class.st
+++ b/src/SmallSuiteGenerator/SExpression.class.st
@@ -72,6 +72,7 @@ SExpression >> copy [
 		id: self id;
 		returnType: self returnType;
 		mutated: self mutated;
+		needsBeFixed: self needsBeFixed;
 		parent: self         
 ]
 
@@ -79,6 +80,10 @@ SExpression >> copy [
 SExpression >> error: aString [
 	"It throws an error signal with the string passed as argument, it is important to distinguish parsing error with others"
 	^ SError signal: aString
+]
+
+{ #category : #fixing }
+SExpression >> fixWith: anObject in: aTestCase [
 ]
 
 { #category : #comparing }

--- a/src/SmallSuiteGenerator/SExpression.class.st
+++ b/src/SmallSuiteGenerator/SExpression.class.st
@@ -17,7 +17,8 @@ Class {
 		'randomGenerator',
 		'mutated',
 		'parent',
-		'identifier'
+		'identifier',
+		'needsBeFixed'
 	],
 	#classInstVars : [
 		'nextId'
@@ -105,7 +106,8 @@ SExpression >> initialize [
 	super initialize .
    randomGenerator := SPlatform randomGenerator.
 	mutated := false.
-	identifier := self class nextIdentifier 
+	identifier := self class nextIdentifier.
+	needsBeFixed := false
 ]
 
 { #category : #mutation }
@@ -154,6 +156,16 @@ SExpression >> mutated [
 { #category : #accessing }
 SExpression >> mutated: aBoolean [
 	mutated := aBoolean
+]
+
+{ #category : #accessing }
+SExpression >> needsBeFixed [
+	^ needsBeFixed
+]
+
+{ #category : #accessing }
+SExpression >> needsBeFixed: aBoolean [
+	needsBeFixed := aBoolean 
 ]
 
 { #category : #accessing }

--- a/src/SmallSuiteGenerator/SFieldAccessMessage.class.st
+++ b/src/SmallSuiteGenerator/SFieldAccessMessage.class.st
@@ -33,6 +33,13 @@ SFieldAccessMessage >> changeSelectorFrom: expression in: aTestCase [
 	self selector: otherFieldAccessMessage selector
 ]
 
+{ #category : #fixing }
+SFieldAccessMessage >> fixWith: anObject in: aTestCase [
+	(anObject receiver types includes: receiver returnType) ifFalse: [ self halt ].
+	returnType := randomGenerator selectAtRandom: anObject returnType types.
+	needsBeFixed := true.
+]
+
 { #category : #mutation }
 SFieldAccessMessage >> insertOn: aTestCase [
 	^ aTestCase addFieldAccessMessage: self selector from: self receiver returnType

--- a/src/SmallSuiteGenerator/SFieldAccessMessage.class.st
+++ b/src/SmallSuiteGenerator/SFieldAccessMessage.class.st
@@ -20,7 +20,8 @@ SFieldAccessMessage class >> newFromReceiver: aReceiver andMethod: aMethod [
 		returnType: aMethod returnType type;
 		selector: aMethod selector;
 		receiver: aReceiver;
-		yourself
+		needsBeFixed: aMethod hasProfiler not;
+		yourself 
 ]
 
 { #category : #override }

--- a/src/SmallSuiteGenerator/SFieldAccessMessage.class.st
+++ b/src/SmallSuiteGenerator/SFieldAccessMessage.class.st
@@ -37,7 +37,7 @@ SFieldAccessMessage >> changeSelectorFrom: expression in: aTestCase [
 SFieldAccessMessage >> fixWith: anObject in: aTestCase [
 	(anObject receiver types includes: receiver returnType) ifFalse: [ self halt ].
 	returnType := randomGenerator selectAtRandom: anObject returnType types.
-	needsBeFixed := true.
+	needsBeFixed := false.
 ]
 
 { #category : #mutation }

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -187,11 +187,16 @@ SGAEngine >> fitnessFor: aTestCase [
 
 { #category : #actions }
 SGAEngine >> fixPopulation [
+	| targetClassMessages |
+	
+	targetClassMessages := (typeInfo messagesFrom: self targetClassName) removeAllSuchThat: [:method |
+		(method returnType includes: #SUndefinedObject) and: [ method returnType types notEmpty ] ].
+	
 	population do: [ :each |
 		each statements do: [ :stm | 
 			((stm returnType = #SUndefinedObject) and: [ stm value receiver returnType = self targetClassName ] ) ifTrue: [ 
-			((each typeInfo messagesFrom: (stm value receiver returnType)) select: [ :method |
-				(method selector = stm value selector) and: [ (method returnType includes: #SUndefinedObject) not and: [ method returnType types notEmpty ] ] ]) do: [ :method | | returnType |
+			(targetClassMessages select: [ :method | method selector = stm value selector ]) 
+			do: [ :method | | returnType |
 				returnType := randomGenerator selectAtRandom: method returnType types asArray.
 				stm returnType: returnType.
 				stm variable returnType: returnType.
@@ -207,9 +212,7 @@ SGAEngine >> initialize [
   randomGenerator := SPlatform newRandomGenerator.
   populationSize := 100.
   numberOfGenerations := 100.
-  "selectionStrategy := SGARankSelection new."
-  "selectionStrategy := SGATournamentSelection new."
-  selectionStrategy := SGATruncatedSelection new.
+  selectionStrategy := SGARankSelection new.
   
   self initializeMutationOperator.
   self initializeCrossoverOperator
@@ -387,8 +390,8 @@ SGAEngine >> run [
 ]
 
 { #category : #accessing }
-SGAEngine >> selectionStrategy [ 
-	^ selectionStrategy
+SGAEngine >> selectionStrategy: aSelectionStrategy [
+	selectionStrategy := aSelectionStrategy 
 ]
 
 { #category : #actions }

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -101,7 +101,9 @@ SGAEngine >> completeTypeInfo [
 		(key isUnary not and: [ value argTypes allSatisfy: [ :arg | arg types notEmpty ] ]) ifTrue:[
 		realClassInfo methodTypes at: key
 		ifPresent: [  ]
-		ifAbsentPut: [ value returnType types ifEmpty: [value returnType type: #SUndefinedObject].
+		ifAbsentPut: [ 
+			self updateArgsOf: value.
+			value returnType types ifEmpty: [value returnType type: #SUndefinedObject].
 			value receiver type: aClass.
 			value hasProfiler: false.
 			value executions: 0.5 ] ] ] ].
@@ -146,9 +148,9 @@ SGAEngine >> createNewPopulation [
 			  [:a :b |  self is: a betterThan: b ].
         selectedOptions := options first: 2.
         selectedOptions do: [:option |  newPopulation add: (option idPopulation: newPopulation size + 1) ] ].
-  population := newPopulation.
   self updateTypeInfoWith: newPopulation.
-  self fixPopulation.
+  self fixPopulation: newPopulation.
+  population := newPopulation.
 ]
 
 { #category : #actions }
@@ -199,19 +201,17 @@ SGAEngine >> fitnessFor: aTestCase [
 ]
 
 { #category : #actions }
-SGAEngine >> fixPopulation [
+SGAEngine >> fixPopulation: aCollection [ 
 	| targetClassMessages |
 	targetClassMessages := (typeInfo types at: self targetClassName)methodTypes values asOrderedCollection 
 		removeAllSuchThat: [:method | method hasProfiler not ].
 	 
-	population do: [ :testCase |
+	aCollection do: [ :testCase |
 		testCase statements select: #needsBeFixed thenDo: [ :stm | 
 			(stm value receiver returnType = self targetClassName) ifTrue: [ 
 			targetClassMessages select: [ :method | method selector = stm value selector ]
 			thenDo: [ :method |
-				stm value fixWith: method in: testCase.
-				stm returnType: stm value returnType.
-				stm variable returnType: stm value returnType.]
+				stm fixWith: method in: testCase ]
 	   ] ] ]
 ]
 
@@ -445,6 +445,18 @@ SGAEngine >> uninstall [
 	typeInfoProfiler afterProfiling;
 		uninstall.
 	Transcript show: 'ended...'; cr.
+]
+
+{ #category : #updating }
+SGAEngine >> updateArgsOf: aMethod [ 
+	aMethod argTypes do: [ :argType |
+	|res|
+	res := argType types anySatisfy: [ :type | typeInfo scalars keys includes: type ].
+	res ifFalse: [ argType types do: [ :type | | scalars |
+		scalars := typeInfo scalars keys select: [ :scalar | 
+			 (type asClass allSubclasses collect: #name) includes: scalar ] thenDo: [ :scalar |
+			argType type: scalar ] ] ]
+	"self scalars keys select: [:e | (String allSubclasses collect: #name) includes: e]."]
 ]
 
 { #category : #updating }

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -201,7 +201,7 @@ SGAEngine >> fitnessFor: aTestCase [
 { #category : #actions }
 SGAEngine >> fixPopulation [
 	| targetClassMessages |
-	targetClassMessages := (typeInfo types at: #SSTeacher )methodTypes values asOrderedCollection 
+	targetClassMessages := (typeInfo types at: self targetClassName)methodTypes values asOrderedCollection 
 		removeAllSuchThat: [:method | method hasProfiler not ].
 	 
 	population do: [ :testCase |

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -133,7 +133,8 @@ SGAEngine >> createNewPopulation [
         selectedOptions do: [:option |  newPopulation add: (option idPopulation: newPopulation size + 1) ]
 		   ].
   population := newPopulation.
-  self updateTypeInfoOfPopulation
+  self updateTypeInfoOfPopulation.
+  self fixPopulation
 		  
 ]
 
@@ -181,6 +182,19 @@ SGAEngine >> fitness: aFitness [
 { #category : #actions }
 SGAEngine >> fitnessFor: aTestCase [
 	^ aTestCase fitness at: fitness functionName.
+]
+
+{ #category : #actions }
+SGAEngine >> fixPopulation [
+	population do: [ :each |
+		each statements do: [ :stm | stm returnType = #SUndefinedObject ifTrue: [ 
+			((each typeInfo messagesFrom: (stm value receiver returnType)) select: [ :method |
+				(method selector = stm value selector) and: [ (method returnType includes: #SUndefinedObject) not ] ]) do: [ :method | | returnType |
+				returnType := randomGenerator selectAtRandom: method returnType types asArray.
+				stm returnType: returnType.
+				stm variable returnType: returnType.
+				stm value returnType: returnType]
+	   ] ] ]
 ]
 
 { #category : #initialization }
@@ -338,7 +352,7 @@ SGAEngine >> profilerForPackagesMatching [
 	typeInfoProfiler beforeProfiling.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #updating }
 SGAEngine >> profilerForTargetClass [
 	| packageSpy cls classSpy |
 	cls := Smalltalk at: targetClassName .

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -176,7 +176,8 @@ SGAEngine >> fitness [
 
 { #category : #accessing }
 SGAEngine >> fitness: aFitness [
-	fitness := aFitness
+	fitness := aFitness.
+	selectionStrategy fitness: aFitness
 ]
 
 { #category : #actions }
@@ -206,7 +207,9 @@ SGAEngine >> initialize [
   randomGenerator := SPlatform newRandomGenerator.
   populationSize := 100.
   numberOfGenerations := 100.
-  selectionStrategy := SGARankSelection new.
+  "selectionStrategy := SGARankSelection new."
+  "selectionStrategy := SGATournamentSelection new."
+  selectionStrategy := SGATruncatedSelection new.
   
   self initializeMutationOperator.
   self initializeCrossoverOperator

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -92,6 +92,21 @@ SGAEngine >> collectFitnessByName [
 	^ dictFit
 ]
 
+{ #category : #'as yet unclassified' }
+SGAEngine >> completeTypeInfo [
+	typeInfo types keysDo: [:aClass | |classInfo realClassInfo|
+	classInfo := SmallTypeCollector new collectTypeFrom: aClass asClass.
+	realClassInfo := typeInfo types at: aClass.
+	classInfo methodTypes keysAndValuesDo: [ :key :value | 
+		(key isUnary not and: [ value argTypes allSatisfy: [ :arg | arg types notEmpty ] ]) ifTrue:[
+		realClassInfo methodTypes at: key
+		ifPresent: [  ]
+		ifAbsentPut: [ value returnType types ifEmpty: [value returnType type: #SUndefinedObject].
+			value receiver type: aClass.
+			value hasProfiler: false.
+			value executions: 0.5 ] ] ] ].
+]
+
 { #category : #actions }
 SGAEngine >> computeFitness [
 	fitness compute: population.
@@ -426,7 +441,8 @@ SGAEngine >> typeInfo [
 
 { #category : #accessing }
 SGAEngine >> typeInfo: aTypeInfo [
-	typeInfo := aTypeInfo
+	typeInfo := aTypeInfo.
+	self completeTypeInfo
 ]
 
 { #category : #updating }
@@ -439,7 +455,7 @@ SGAEngine >> uninstall [
 { #category : #updating }
 SGAEngine >> updateTypeInfoOfPopulation [
 	fitness profiler uninstallClass: targetClassName.
-   self profilerForTargetClass .
+   self profilerForTargetClass.
    population do:
 		[ :testCase | testCase runWithoutAssertions ].
    self mergeTypeInfo: (STypeInfo asTypeInfo: typeInfoProfiler).

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -92,7 +92,7 @@ SGAEngine >> collectFitnessByName [
 	^ dictFit
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #updating }
 SGAEngine >> completeTypeInfo [
 	typeInfo types keysDo: [:aClass | |classInfo realClassInfo|
 	classInfo := SmallTypeCollector new collectTypeFrom: aClass asClass.
@@ -145,12 +145,10 @@ SGAEngine >> createNewPopulation [
         options := options asSortedCollection: 
 			  [:a :b |  self is: a betterThan: b ].
         selectedOptions := options first: 2.
-        selectedOptions do: [:option |  newPopulation add: (option idPopulation: newPopulation size + 1) ]
-		   ].
+        selectedOptions do: [:option |  newPopulation add: (option idPopulation: newPopulation size + 1) ] ].
   population := newPopulation.
-  self updateTypeInfoOfPopulation.
-  self fixPopulation
-		  
+  self updateTypeInfoWith: newPopulation.
+  self fixPopulation.
 ]
 
 { #category : #actions }
@@ -203,19 +201,17 @@ SGAEngine >> fitnessFor: aTestCase [
 { #category : #actions }
 SGAEngine >> fixPopulation [
 	| targetClassMessages |
-	
-	targetClassMessages := (typeInfo messagesFrom: self targetClassName) removeAllSuchThat: [:method |
-		(method returnType includes: #SUndefinedObject) and: [ method returnType types notEmpty ] ].
-	
-	population do: [ :each |
-		each statements do: [ :stm | 
-			((stm returnType = #SUndefinedObject) and: [ stm value receiver returnType = self targetClassName ] ) ifTrue: [ 
-			(targetClassMessages select: [ :method | method selector = stm value selector ]) 
-			do: [ :method | | returnType |
-				returnType := randomGenerator selectAtRandom: method returnType types asArray.
-				stm returnType: returnType.
-				stm variable returnType: returnType.
-				stm value returnType: returnType]
+	targetClassMessages := (typeInfo types at: #SSTeacher )methodTypes values asOrderedCollection 
+		removeAllSuchThat: [:method | method hasProfiler not ].
+	 
+	population do: [ :testCase |
+		testCase statements select: #needsBeFixed thenDo: [ :stm | 
+			(stm value receiver returnType = self targetClassName) ifTrue: [ 
+			targetClassMessages select: [ :method | method selector = stm value selector ]
+			thenDo: [ :method |
+				stm value fixWith: method in: testCase.
+				stm returnType: stm value returnType.
+				stm variable returnType: stm value returnType.]
 	   ] ] ]
 ]
 
@@ -293,8 +289,7 @@ SGAEngine >> logs [
 
 { #category : #updating }
 SGAEngine >> mergeTypeInfo: otherTypeInfo [
-	initialPopulation do: [ :testCase | testCase typeInfo joinWith: otherTypeInfo ].
-	population do: [ :testCase | testCase typeInfo joinWith: otherTypeInfo ].
+	typeInfo joinWith: otherTypeInfo.
 ]
 
 { #category : #actions }
@@ -453,10 +448,10 @@ SGAEngine >> uninstall [
 ]
 
 { #category : #updating }
-SGAEngine >> updateTypeInfoOfPopulation [
+SGAEngine >> updateTypeInfoWith: aPopulation [
 	fitness profiler uninstallClass: targetClassName.
    self profilerForTargetClass.
-   population do:
+   aPopulation do:
 		[ :testCase | testCase runWithoutAssertions ].
    self mergeTypeInfo: (STypeInfo asTypeInfo: typeInfoProfiler).
    self uninstall .

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -106,7 +106,7 @@ SGAEngine >> completeTypeInfo [
 			value returnType types ifEmpty: [value returnType type: #SUndefinedObject].
 			value receiver type: aClass.
 			value hasProfiler: false.
-			value executions: 0.5 ] ] ] ].
+			value executions: 0.5 ] ] ] ]
 ]
 
 { #category : #actions }
@@ -455,8 +455,7 @@ SGAEngine >> updateArgsOf: aMethod [
 	res ifFalse: [ argType types do: [ :type | | scalars |
 		scalars := typeInfo scalars keys select: [ :scalar | 
 			 (type asClass allSubclasses collect: #name) includes: scalar ] thenDo: [ :scalar |
-			argType type: scalar ] ] ]
-	"self scalars keys select: [:e | (String allSubclasses collect: #name) includes: e]."]
+			argType type: scalar ] ] ] ]
 ]
 
 { #category : #updating }

--- a/src/SmallSuiteGenerator/SGAEngine.class.st
+++ b/src/SmallSuiteGenerator/SGAEngine.class.st
@@ -187,9 +187,10 @@ SGAEngine >> fitnessFor: aTestCase [
 { #category : #actions }
 SGAEngine >> fixPopulation [
 	population do: [ :each |
-		each statements do: [ :stm | stm returnType = #SUndefinedObject ifTrue: [ 
+		each statements do: [ :stm | 
+			((stm returnType = #SUndefinedObject) and: [ stm value receiver returnType = self targetClassName ] ) ifTrue: [ 
 			((each typeInfo messagesFrom: (stm value receiver returnType)) select: [ :method |
-				(method selector = stm value selector) and: [ (method returnType includes: #SUndefinedObject) not ] ]) do: [ :method | | returnType |
+				(method selector = stm value selector) and: [ (method returnType includes: #SUndefinedObject) not and: [ method returnType types notEmpty ] ] ]) do: [ :method | | returnType |
 				returnType := randomGenerator selectAtRandom: method returnType types asArray.
 				stm returnType: returnType.
 				stm variable returnType: returnType.

--- a/src/SmallSuiteGenerator/SGASelection.class.st
+++ b/src/SmallSuiteGenerator/SGASelection.class.st
@@ -4,8 +4,16 @@ Abstract class for strategy selection
 Class {
 	#name : #SGASelection,
 	#superclass : #SGAObject,
+	#instVars : [
+		'fitness'
+	],
 	#category : #'SmallSuiteGenerator-GA'
 }
+
+{ #category : #accessing }
+SGASelection >> fitness: anObject [ 
+	fitness := anObject 
+]
 
 { #category : #initialization }
 SGASelection >> initialize [

--- a/src/SmallSuiteGenerator/SGATournamentSelection.class.st
+++ b/src/SmallSuiteGenerator/SGATournamentSelection.class.st
@@ -5,16 +5,10 @@ Class {
 	#name : #SGATournamentSelection,
 	#superclass : #SGASelection,
 	#instVars : [
-		'tournamentSize',
-		'fitness'
+		'tournamentSize'
 	],
 	#category : #'SmallSuiteGenerator-GA'
 }
-
-{ #category : #actions }
-SGATournamentSelection >> fitness: anObject [ 
-	fitness := anObject 
-]
 
 { #category : #actions }
 SGATournamentSelection >> fitnessFor: aTestCase [
@@ -35,7 +29,7 @@ SGATournamentSelection >> selectOf: aCollection [
 	sample := (randomGenerator collectAtRandom: aCollection )
 		first: (tournamentSize min: aCollection size).
 	sample := sample
-		asSortedCollection: [ :a :b | (self fitnessFor: a) > (self fitnessFor: b) ].
+		asSortedCollection: [ :a :b | (a fitness at: fitness functionName) > (b fitness  at: fitness functionName) ].
 	^ sample
 ]
 

--- a/src/SmallSuiteGenerator/SGATruncatedSelection.class.st
+++ b/src/SmallSuiteGenerator/SGATruncatedSelection.class.st
@@ -4,15 +4,29 @@ SGATrouncateSelection is responsible for select testCases, this type of selectio
 Class {
 	#name : #SGATruncatedSelection,
 	#superclass : #SGASelection,
+	#instVars : [
+		'discarding'
+	],
 	#category : #'SmallSuiteGenerator-GA'
 }
 
-{ #category : #'as yet unclassified' }
-SGATruncatedSelection >> selectOf: aCollection descarting: aNumber [
-	(aNumber < aCollection size)
-		ifTrue: [ | newColl |
-			newColl := (aCollection sort: [ :a :b | a fitness > b fitness ]) copyFrom: 1 to: (aCollection size - aNumber).
-			^ randomGenerator selectAtRandom: newColl
+{ #category : #actions }
+SGATruncatedSelection >> discarding: aNumber [
+	discarding := aNumber
+]
+
+{ #category : #initialization }
+SGATruncatedSelection >> initialize [ 
+	discarding := 5
+]
+
+{ #category : #actions }
+SGATruncatedSelection >> selectOf: aCollection [
+	| newColl |
+	newColl := (aCollection sort: [ :a :b |(a fitness at: fitness functionName)> (b fitness at: fitness functionName) ]).
+	(discarding < aCollection size)
+		ifTrue: [
+			newColl := newColl copyFrom: 1 to: (aCollection size - discarding)
 		].
-	^ nil
+	^ newColl
 ]

--- a/src/SmallSuiteGenerator/SMessage.class.st
+++ b/src/SmallSuiteGenerator/SMessage.class.st
@@ -43,6 +43,16 @@ SMessage >> changeSelectorFrom: aExpression in: aTestCase [
 	self args: otherMessage args
 ]
 
+{ #category : #fixing }
+SMessage >> fixWith: anObject in: aTestCase [
+	(anObject receiver types includes: receiver returnType) ifFalse: [ self halt ].
+	returnType := randomGenerator selectAtRandom: anObject returnType types.
+	anObject argTypes with: args do: [ :arg1 :arg2 | 
+		(arg1 types includes: arg2 returnType) ifFalse: [ self halt. ]
+		 ].
+	needsBeFixed := true.
+]
+
 { #category : #mutation }
 SMessage >> insertMethodMessage: aExpression using: aTestCase [
 	^ self insertRandomMessage: aExpression using: aTestCase

--- a/src/SmallSuiteGenerator/SMessage.class.st
+++ b/src/SmallSuiteGenerator/SMessage.class.st
@@ -28,6 +28,7 @@ SMessage class >> newFromReceiver: aReceiver method: aMethod andPreviousStatemen
 		selector: aMethod selector;
 		receiver: aReceiver;
 		args: (self args: aMethod with: statements);
+		needsBeFixed: aMethod hasProfiler not;
 		yourself
 ]
 

--- a/src/SmallSuiteGenerator/SMessage.class.st
+++ b/src/SmallSuiteGenerator/SMessage.class.st
@@ -50,7 +50,7 @@ SMessage >> fixWith: anObject in: aTestCase [
 	anObject argTypes with: args do: [ :arg1 :arg2 | 
 		(arg1 types includes: arg2 returnType) ifFalse: [ self halt. ]
 		 ].
-	needsBeFixed := true.
+	needsBeFixed := false.
 ]
 
 { #category : #mutation }

--- a/src/SmallSuiteGenerator/SMultiTypeInfo.class.st
+++ b/src/SmallSuiteGenerator/SMultiTypeInfo.class.st
@@ -96,6 +96,7 @@ SMultiTypeInfo >> isBlockSymbol [
 
 { #category : #actions }
 SMultiTypeInfo >> joinWith: otherTypeReturn [
+	(types includes: #SUndefinedObject) ifTrue: [ self initialize ].
 	otherTypeReturn types do: [ :aType | self type: aType ]
 ]
 

--- a/src/SmallSuiteGenerator/SMultiTypeInfo.class.st
+++ b/src/SmallSuiteGenerator/SMultiTypeInfo.class.st
@@ -96,8 +96,8 @@ SMultiTypeInfo >> isBlockSymbol [
 
 { #category : #actions }
 SMultiTypeInfo >> joinWith: otherTypeReturn [
-	((types includes: #SUndefinedObject) and: [ (otherTypeReturn types includes: #SUndefinedObject) not ]) ifTrue: [ self initialize ].
-	otherTypeReturn types do: [ :aType | self type: aType ]
+	otherTypeReturn types do: [ :aType | self type: aType ].
+	types size > 1 ifTrue: [ types remove: #SUndefinedObject ifAbsent: [ ] ]
 ]
 
 { #category : #'ston persistence' }

--- a/src/SmallSuiteGenerator/SMultiTypeInfo.class.st
+++ b/src/SmallSuiteGenerator/SMultiTypeInfo.class.st
@@ -96,7 +96,7 @@ SMultiTypeInfo >> isBlockSymbol [
 
 { #category : #actions }
 SMultiTypeInfo >> joinWith: otherTypeReturn [
-	(types includes: #SUndefinedObject) ifTrue: [ self initialize ].
+	((types includes: #SUndefinedObject) and: [ (otherTypeReturn types includes: #SUndefinedObject) not ]) ifTrue: [ self initialize ].
 	otherTypeReturn types do: [ :aType | self type: aType ]
 ]
 

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,23 +48,28 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var18 _var1 _var2 _var3 _var4 _var5 _var6 _var7 _var16 _var0 _var8 _var9 _var10 _var11 _var13 _var14 |
-_var18 := 400.
-_var1 := 'teacher_teacher_teacher_Ann'.
-_var2 := SSTeacher name: _var1 with: _var18.
-_var3 := _var2 resetIdTeacher.
-_var4 := _var2 idTeacher.
-_var5 := _var2 id: _var4.
-_var6 := _var5 resetYearsWorkExperience.
-_var7 := _var2 yearsWorkExperience.
-_var16 := _var2 resetIdTeacher.
-_var0 := _var5 yearsWorkExperience.
-_var8 := _var2 yearsWorkExperience.
-_var9 := _var2 nickname.
-_var10 := _var6 idTeacher.
-_var11 := _var6 yearsWorkExperience.
-_var13 := SConference price: _var7.
-_var14 := _var13 price: _var0.
+	| _var0 _var1 _var27 _var2 _var3 _var4 _var5 _var6 _var7 _var8 _var10 _var11 _var12 _var13 _var14 _var9 _var15 _var16 _var17 _var18 _var21 |
+_var0 := RTGrapher new.
+_var1 := _var0 maxY.
+_var27 := RTGrapher new.
+_var2 := _var0 renderLegend.
+_var3 := RTData new.
+_var4 := RTData basicNew yourself.
+_var5 := _var0 add: _var3.
+_var6 := _var4 defaultMinValue.
+_var7 := _var27 resetShape.
+_var8 := _var0 initialize.
+_var10 := false.
+_var11 := _var7 shouldUseNiceLabelsForX: _var10.
+_var12 := _var7 homogenizeMinAndMax.
+_var13 := RTEllipse new.
+_var14 := RTBox new.
+_var9 := _var8 maxX.
+_var15 := _var4 defaultMinValue.
+_var16 := _var2 maxX.
+_var17 := _var27 maxX.
+_var18 := _var8 initialize.
+_var21 := _var8 initialize.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,24 +48,33 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var24 _var25 _var2 _var3 _var1 _var0 _var4 _var5 _var6 _var7 _var8 _var9 _var11 _var12 _var10 _var13 |
-_var24 := 'Ann'.
-_var25 := 50.
-_var2 := SSTeacher name: _var24 with: _var25.
-_var3 := _var2 resetYearsWorkExperience.
-_var1 := _var2 idTeacher.
-_var0 := _var2 resetIdTeacher.
-_var4 := _var2 yearsWorkExperience.
-_var5 := _var3 yearsWorkExperience.
-_var6 := _var3 yearsWorkExperience.
-_var7 := _var2 resetIdTeacher.
-_var8 := _var2 idTeacher.
-_var9 := _var3 nickname.
-_var11 := _var3 id: _var1.
-_var12 := _var2 idTeacher.
-_var10 := _var3 initialize.
-_var13 := _var10 yearsWorkExperience.
-^self analyze: thisContext
+	| var |
+var := Dictionary new.
+var at: 1 put: PDFDocument new.
+var at: 29 put: PDFDocument new.
+var at: 2 put: (var at: 1) styleSheet.
+var at: 28 put: (var at: 1) format.
+var at: 5 put: (var at: 1) styleSheet.
+var at: 6 put: (var at: 29) orientation.
+var at: 7 put: (var at: 28) size.
+var at: 9 put: (var at: 1) metaData.
+var at: 10 put: (var at: 9) producer.
+var at: 8 put: 'Artefact'.
+var at: 11 put: ((var at: 9) creator: (var at: 8)).
+var at: 12 put: (var at: 1) zoom.
+var at: 3 put: (var at: 1) real.
+var at: 4 put: (var at: 28) size.
+var at: 14 put: ''.
+var at: 15 put: ((var at: 9) producer: (var at: 8)).
+var at: 16 put: (var at: 15) subject.
+var at: 17 put: (var at: 11) producer.
+var at: 18 put: (var at: 3) generate.
+var at: 19 put: (var at: 1) real.
+var at: 21 put: ((var at: 9) producer: (var at: 14)).
+var at: 22 put: PDFPage basicNew yourself.
+var at: 23 put: ((var at: 19) add: (var at: 22)).
+var at: 25 put: ((var at: 21) producer: (var at: 14)).
+var at: 26 put: (var at: 1) real
 ]
 
 { #category : #running }

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,23 +48,20 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 _var2 _var3 _var4 _var5 _var6 _var7 _var8 _var9 _var10 _var12 _var14 _var15 _var16 _var17 |
+	| _var0 _var14 _var1 _var2 _var3 _var4 _var5 _var7 _var8 _var6 _var9 _var10 _var11 |
 _var0 := RTGrapher new.
-_var1 := _var0 createLegendBuilder.
-_var2 := RTData new.
-_var3 := _var0 add: _var2.
-_var4 := _var3 maxX.
-_var5 := _var0 datasets.
-_var6 := _var3 resetLegend.
-_var7 := _var3 numberOfDecorators.
-_var8 := _var0 renderLegend.
-_var9 := _var3 maxYFromDataSets.
-_var10 := _var6 createInteractionBuilder.
-_var12 := _var6 add: _var2.
-_var14 := false.
-_var15 := _var0 shouldUseNiceLabelsForX: _var14.
-_var16 := _var0 maxY.
-_var17 := _var12 defaultWindowName.
+_var14 := RTGrapher new.
+_var1 := _var0 resetShape.
+_var2 := _var0 initialize.
+_var3 := _var0 resetLegend.
+_var4 := _var1 resetLegend.
+_var5 := RTData new.
+_var7 := _var14 add: _var5.
+_var8 := _var2 configureForBarCharts.
+_var6 := _var14 configureForBarCharts.
+_var9 := _var0 configureForBarCharts.
+_var10 := _var7 resetInteraction.
+_var11 := _var0 defaultWindowName.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,28 +48,23 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 _var27 _var2 _var3 _var4 _var5 _var6 _var7 _var8 _var10 _var11 _var12 _var13 _var14 _var9 _var15 _var16 _var17 _var18 _var21 |
-_var0 := RTGrapher new.
-_var1 := _var0 maxY.
-_var27 := RTGrapher new.
-_var2 := _var0 renderLegend.
-_var3 := RTData new.
-_var4 := RTData basicNew yourself.
-_var5 := _var0 add: _var3.
-_var6 := _var4 defaultMinValue.
-_var7 := _var27 resetShape.
-_var8 := _var0 initialize.
-_var10 := false.
-_var11 := _var7 shouldUseNiceLabelsForX: _var10.
-_var12 := _var7 homogenizeMinAndMax.
-_var13 := RTEllipse new.
-_var14 := RTBox new.
-_var9 := _var8 maxX.
-_var15 := _var4 defaultMinValue.
-_var16 := _var2 maxX.
-_var17 := _var27 maxX.
-_var18 := _var8 initialize.
-_var21 := _var8 initialize.
+	| _var24 _var25 _var2 _var3 _var1 _var0 _var4 _var5 _var6 _var7 _var8 _var9 _var11 _var12 _var10 _var13 |
+_var24 := 'Ann'.
+_var25 := 50.
+_var2 := SSTeacher name: _var24 with: _var25.
+_var3 := _var2 resetYearsWorkExperience.
+_var1 := _var2 idTeacher.
+_var0 := _var2 resetIdTeacher.
+_var4 := _var2 yearsWorkExperience.
+_var5 := _var3 yearsWorkExperience.
+_var6 := _var3 yearsWorkExperience.
+_var7 := _var2 resetIdTeacher.
+_var8 := _var2 idTeacher.
+_var9 := _var3 nickname.
+_var11 := _var3 id: _var1.
+_var12 := _var2 idTeacher.
+_var10 := _var3 initialize.
+_var13 := _var10 yearsWorkExperience.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,33 +48,27 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| var |
-var := Dictionary new.
-var at: 1 put: PDFDocument new.
-var at: 29 put: PDFDocument new.
-var at: 2 put: (var at: 1) styleSheet.
-var at: 28 put: (var at: 1) format.
-var at: 5 put: (var at: 1) styleSheet.
-var at: 6 put: (var at: 29) orientation.
-var at: 7 put: (var at: 28) size.
-var at: 9 put: (var at: 1) metaData.
-var at: 10 put: (var at: 9) producer.
-var at: 8 put: 'Artefact'.
-var at: 11 put: ((var at: 9) creator: (var at: 8)).
-var at: 12 put: (var at: 1) zoom.
-var at: 3 put: (var at: 1) real.
-var at: 4 put: (var at: 28) size.
-var at: 14 put: ''.
-var at: 15 put: ((var at: 9) producer: (var at: 8)).
-var at: 16 put: (var at: 15) subject.
-var at: 17 put: (var at: 11) producer.
-var at: 18 put: (var at: 3) generate.
-var at: 19 put: (var at: 1) real.
-var at: 21 put: ((var at: 9) producer: (var at: 14)).
-var at: 22 put: PDFPage basicNew yourself.
-var at: 23 put: ((var at: 19) add: (var at: 22)).
-var at: 25 put: ((var at: 21) producer: (var at: 14)).
-var at: 26 put: (var at: 1) real
+	| _var1 _var2 _var3 _var4 _var0 _var5 _var6 _var7 _var8 _var9 _var10 _var11 _var12 _var13 _var14 _var15 _var16 _var18 _var19 |
+_var1 := SSTeacher new.
+_var2 := _var1 yearsWorkExperience.
+_var3 := _var1 initialize.
+_var4 := _var1 initialize.
+_var0 := 'Ann'.
+_var5 := _var1 name: _var0.
+_var6 := _var1 initialize.
+_var7 := 50.
+_var8 := _var3 yearsWorkExperience: _var7.
+_var9 := 0.
+_var10 := _var8 id: _var9.
+_var11 := _var4 idTeacher.
+_var12 := _var10 initialize.
+_var13 := 50.
+_var14 := _var8 id: _var13.
+_var15 := _var10 nickname.
+_var16 := _var12 id: _var9.
+_var18 := _var12 id: _var7.
+_var19 := _var5 idTeacher.
+^self analyze: thisContext
 ]
 
 { #category : #running }

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,21 +48,9 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 _var2 _var5 _var6 _var7 _var8 _var9 _var10 _var11 _var12 _var13 _var14 |
-_var0 := 'teacher_Ann'.
-_var1 := SSTeacher new.
-_var2 := _var1 idTeacher.
-_var5 := SSTeacher name: _var0 with: _var2.
-_var6 := _var1 yearsWorkExperience.
-_var7 := _var5 nickname.
-_var8 := SSTeacher new.
-_var9 := _var1 nickname.
-_var10 := _var5 nickname.
-_var11 := _var8 yearsWorkExperience.
-_var12 := _var8 idTeacher.
-_var13 := _var1 nickname.
-_var14 := _var8 yearsWorkExperience.
-^self analyze: thisContext
+	| _var0 _var1 |
+_var0 := RTView new.
+_var1 := _var0 canvas
 ]
 
 { #category : #running }

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,26 +48,23 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var1 _var2 _var3 _var4 _var0 _var5 _var6 _var7 _var8 _var9 _var10 _var11 _var12 _var13 _var14 _var15 _var16 _var18 _var19 |
-_var1 := SSTeacher new.
-_var2 := _var1 yearsWorkExperience.
-_var3 := _var1 initialize.
-_var4 := _var1 initialize.
-_var0 := 'Ann'.
-_var5 := _var1 name: _var0.
-_var6 := _var1 initialize.
-_var7 := 50.
-_var8 := _var3 yearsWorkExperience: _var7.
-_var9 := 0.
-_var10 := _var8 id: _var9.
-_var11 := _var4 idTeacher.
-_var12 := _var10 initialize.
-_var13 := 50.
-_var14 := _var8 id: _var13.
-_var15 := _var10 nickname.
-_var16 := _var12 id: _var9.
-_var18 := _var12 id: _var7.
-_var19 := _var5 idTeacher.
+	| _var0 _var1 _var2 _var3 _var4 _var5 _var6 _var7 _var8 _var9 _var10 _var12 _var14 _var15 _var16 _var17 |
+_var0 := RTGrapher new.
+_var1 := _var0 createLegendBuilder.
+_var2 := RTData new.
+_var3 := _var0 add: _var2.
+_var4 := _var3 maxX.
+_var5 := _var0 datasets.
+_var6 := _var3 resetLegend.
+_var7 := _var3 numberOfDecorators.
+_var8 := _var0 renderLegend.
+_var9 := _var3 maxYFromDataSets.
+_var10 := _var6 createInteractionBuilder.
+_var12 := _var6 add: _var2.
+_var14 := false.
+_var15 := _var0 shouldUseNiceLabelsForX: _var14.
+_var16 := _var0 maxY.
+_var17 := _var12 defaultWindowName.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,22 +48,23 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 _var3 _var2 _var4 _var5 _var6 _var7 _var8 _var9 _var10 _var12 _var13 _var14 _var15 |
-_var0 := 'teacher_'.
-_var1 := 0.
-_var3 := SSTeacher name: _var0 with: _var1.
-_var2 := _var3 idTeacher.
-_var4 := _var3 initialize.
-_var5 := _var3 yearsWorkExperience.
-_var6 := _var3 resetYearsWorkExperience.
-_var7 := _var4 yearsWorkExperience.
-_var8 := _var3 resetIdTeacher.
-_var9 := _var3 idTeacher.
-_var10 := _var4 yearsWorkExperience.
-_var12 := _var4 id: _var1.
-_var13 := _var4 resetIdTeacher.
-_var14 := _var12 idTeacher.
-_var15 := _var4 nickname.
+	| _var18 _var1 _var2 _var3 _var4 _var5 _var6 _var7 _var16 _var0 _var8 _var9 _var10 _var11 _var13 _var14 |
+_var18 := 400.
+_var1 := 'teacher_teacher_teacher_Ann'.
+_var2 := SSTeacher name: _var1 with: _var18.
+_var3 := _var2 resetIdTeacher.
+_var4 := _var2 idTeacher.
+_var5 := _var2 id: _var4.
+_var6 := _var5 resetYearsWorkExperience.
+_var7 := _var2 yearsWorkExperience.
+_var16 := _var2 resetIdTeacher.
+_var0 := _var5 yearsWorkExperience.
+_var8 := _var2 yearsWorkExperience.
+_var9 := _var2 nickname.
+_var10 := _var6 idTeacher.
+_var11 := _var6 yearsWorkExperience.
+_var13 := SConference price: _var7.
+_var14 := _var13 price: _var0.
 ^self analyze: thisContext
 ]
 

--- a/src/SmallSuiteGenerator/SSTestRunner.class.st
+++ b/src/SmallSuiteGenerator/SSTestRunner.class.st
@@ -48,9 +48,23 @@ SSTestRunner >> initialize [
 
 { #category : #'as yet unclassified' }
 SSTestRunner >> performTest [
-	| _var0 _var1 |
-_var0 := RTView new.
-_var1 := _var0 canvas
+	| _var0 _var1 _var3 _var2 _var4 _var5 _var6 _var7 _var8 _var9 _var10 _var12 _var13 _var14 _var15 |
+_var0 := 'teacher_'.
+_var1 := 0.
+_var3 := SSTeacher name: _var0 with: _var1.
+_var2 := _var3 idTeacher.
+_var4 := _var3 initialize.
+_var5 := _var3 yearsWorkExperience.
+_var6 := _var3 resetYearsWorkExperience.
+_var7 := _var4 yearsWorkExperience.
+_var8 := _var3 resetIdTeacher.
+_var9 := _var3 idTeacher.
+_var10 := _var4 yearsWorkExperience.
+_var12 := _var4 id: _var1.
+_var13 := _var4 resetIdTeacher.
+_var14 := _var12 idTeacher.
+_var15 := _var4 nickname.
+^self analyze: thisContext
 ]
 
 { #category : #running }

--- a/src/SmallSuiteGenerator/SSTestShifter.class.st
+++ b/src/SmallSuiteGenerator/SSTestShifter.class.st
@@ -782,9 +782,9 @@ SSTestShifter >> numMaxStatements: anObject [
 SSTestShifter >> objectVariables [
 	
 	^ statements select:[:stm| 
-			|res|
-			res := self typeInfo classAt: stm returnType ifNone:[nil].
-			res isNil not] thenCollect:[:stm| stm variable].
+			stm needsBeFixed not and: 
+				[ (self typeInfo classAt: stm returnType ifNone:[nil]) isNil not]] 
+		thenCollect:[:stm| stm variable].
 ]
 
 { #category : #accessing }

--- a/src/SmallSuiteGenerator/SSTestShifter.class.st
+++ b/src/SmallSuiteGenerator/SSTestShifter.class.st
@@ -1166,7 +1166,7 @@ SSTestShifter >> validReferences [
 			variables := stm variablesWithId asSet.
 			references add: stm reference.
 			(references includesAll: variables)
-				ifFalse: [ true ]
+				ifFalse: [self halt. true ]
 				ifTrue: [ references addAll: variables.
 					false ] ]
 		ifFound: [ false ]

--- a/src/SmallSuiteGenerator/SSTestShifter.class.st
+++ b/src/SmallSuiteGenerator/SSTestShifter.class.st
@@ -152,7 +152,7 @@ SSTestShifter >> addMessage [
 	receiver := self pickAnObjectVariable.
 	methods := self pickMessagesOf: receiver returnType.
 	methods
-		ifEmpty: [ self
+		ifEmpty: [self
 				error: 'There are no method typeInfos for: ' , receiver returnType , '.' ]
 		ifNotEmpty: [ ^ self addMessage: (self selectMethod: methods) withReceiver: receiver ]
 ]
@@ -468,8 +468,9 @@ SSTestShifter >> generateAssertions: classAssertions [
 
 { #category : #actions }
 SSTestShifter >> generateStatements [
-	| flag |
+	| flag counter |
 	flag := true.
+	counter := 0.
 	self
 		assert: typeInfo types isNotEmpty
 		description: 'TypeInfo does not contain info at all.'.
@@ -477,8 +478,10 @@ SSTestShifter >> generateStatements [
 		whileTrue: [ 
 			| array |
 			array := randomGenerator collectAtRandom: (Array with: #addMessage with: #addFieldAccessMessage).
-			array detect: [:aMethod | [ (self perform: aMethod) isNotNil ] on: SError do: [ false ] ] ifNone: [ flag := false.
-				self error: 'Not able to generate statements' ].
+			array detect: [:aMethod | [ (self perform: aMethod) isNotNil ] on: SError do: [ false ] ] 				ifNone: [ counter := counter + 1.
+					counter > self maxNumberOfStatements ifTrue: 
+						[ flag := false.
+						  self error: 'Not able to generate statements' ] ].
 		"	[ self addMessage ]
 				on: SError
 				do: [  ]" ]

--- a/src/SmallSuiteGenerator/STestCaseFactory.class.st
+++ b/src/SmallSuiteGenerator/STestCaseFactory.class.st
@@ -16,7 +16,8 @@ Class {
 		'setUpMethod',
 		'tearDownMethod',
 		'lastMessage',
-		'asDict'
+		'asDict',
+		'fitnessSeed'
 	],
 	#classInstVars : [
 		'instance'
@@ -83,7 +84,6 @@ STestCaseFactory >> engineDefault [
 STestCaseFactory >> export: aTestCase with: aSelector [
 	| class |
 	class := self getClassOf: ('GA' , self targetClassName , 'Test').
-	self moveClass: class.
 	[ aTestCase generateAssertions.
 	class
 		compile:
@@ -161,11 +161,10 @@ STestCaseFactory >> getClassOf: aString [
 { #category : #initialization }
 STestCaseFactory >> initialize [
 	super initialize.
-	targetClassName := nil.
-	targetPackageRegex := nil.
 	fitness := SMethodCoverage new.
 	engine := self engineDefault.
 	numberOfIterations :=20.
+	fitnessSeed := 0.
 	outputPackageName := 'SmallSuiteGenerator-Tests-Generated'
 ]
 
@@ -179,10 +178,6 @@ STestCaseFactory >> initializeProfiler [
 STestCaseFactory >> lastMessage: aMessage [
 	lastMessage := aMessage.
 	engine lastMessage: aMessage 
-]
-
-{ #category : #'as yet unclassified' }
-STestCaseFactory >> moveClass: aClass [ 
 ]
 
 { #category : #initialization }
@@ -219,6 +214,11 @@ STestCaseFactory >> run [
 { #category : #'instance creation' }
 STestCaseFactory >> seed: aNumber [ 	
 	SPlatform seed: aNumber
+]
+
+{ #category : #configuration }
+STestCaseFactory >> seedBlock: aBlock [ 	
+	fitnessSeed := (SLProfilerCoverage profile: aBlock inPackagesMatching:targetPackageRegex) statementCoverageFor: targetClassName.
 ]
 
 { #category : #actions }
@@ -291,7 +291,7 @@ STestCaseFactory >> uninstall [
 { #category : #visualization }
 STestCaseFactory >> visualize [
 	| p g d |
-	p := RTPalette c3.
+	p := RTPalette c4.
 	g := RTGrapher new.
 	self fitnessValues associations doWithIndex: [ :association :index | 
 		d := RTData new.
@@ -301,6 +301,11 @@ STestCaseFactory >> visualize [
 			points: association value;
 			label: association key.
 		g add: d ].
+	d := RTData new connectColor: (p at: 4);
+			noDot;
+			points: ((OrderedCollection ofSize: numberOfIterations + 1) atAllPut: fitnessSeed; yourself);
+			label: 'Seed fitness'.
+	g add: d.
 	g legend addText: 'Fitness evolution'.
 	^ g
 ]

--- a/src/SmallSuiteGenerator/STestCaseFactory.class.st
+++ b/src/SmallSuiteGenerator/STestCaseFactory.class.st
@@ -222,6 +222,11 @@ STestCaseFactory >> seedBlock: aBlock [
 ]
 
 { #category : #actions }
+STestCaseFactory >> selectionStrategy: aSelectionStrategy [
+	engine selectionStrategy: aSelectionStrategy 
+]
+
+{ #category : #actions }
 STestCaseFactory >> setUp [
 	self initializeProfiler.
 	fitness profiler: profiler.

--- a/src/SmallSuiteGenerator/STypeClassInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeClassInfo.class.st
@@ -204,7 +204,7 @@ STypeClassInfo >> instanceMethodsFor: aSpyClass [
 				select: [ :each | each wasExecuted or: [ each isUnary ]].
 		instanceMethods do: [ :each | each numberOfExecutions = 0 ifTrue: [
 			each numberOfExecutions: 0.5.
-			each returnValue: nil.
+			each returnValue: SUndefinedObject basicNew.
 			each saveReceiver: (each originalMethod origin)
 		]]
 	].

--- a/src/SmallSuiteGenerator/STypeClassInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeClassInfo.class.st
@@ -202,7 +202,7 @@ STypeClassInfo >> instanceMethodsFor: aSpyClass [
 	(aSpyClass typeName endsWith: ' class') ifFalse: [ 
 		instanceMethods := (aSpyClass methods reject: #isTest)
 				select: [ :each | each wasExecuted or: [ each isUnary ]].
-		instanceMethods do: [ :each | each numberOfExecutions = 0 ifTrue: [
+		instanceMethods do: [ :each | each wasExecuted ifFalse: [
 			each numberOfExecutions: 0.5.
 			each returnValue: SUndefinedObject basicNew.
 			each saveReceiver: (each originalMethod origin)

--- a/src/SmallSuiteGenerator/STypeClassInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeClassInfo.class.st
@@ -110,19 +110,12 @@ STypeClassInfo >> allMethods [
 	^ methodTypes values , classMethodTypes values
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 STypeClassInfo >> asClassInfo: aSpyClass [
 	| aTypeClass instanceMethods classMethods |
 	aTypeClass := self class newFrom: aSpyClass typeName.
-	instanceMethods := OrderedCollection new.
-	classMethods := OrderedCollection new.
-	(aSpyClass typeName endsWith: ' class') ifFalse: [ 
-		instanceMethods := (aSpyClass methods reject: #isTest)
-				select: #wasExecuted
-	].
-	(aSpyClass metaclassSpy typeName endsWith: ' class') ifTrue: [ 
-		classMethods := (aSpyClass metaclassSpy methods reject: #isTest) select:
-					[ :clsMethod | clsMethod wasExecuted and: [ clsMethod isValidReturnTypeWithReceiver ] ] 	].
+	instanceMethods := self instanceMethodsFor: aSpyClass.
+	classMethods := self classMethodsFor: aSpyClass .
 	aTypeClass
 		addMethods:
 			(instanceMethods
@@ -141,6 +134,16 @@ STypeClassInfo >> classMethodOf: aSelector [
 { #category : #accessing }
 STypeClassInfo >> classMethodTypes [
 	^ classMethodTypes
+]
+
+{ #category : #acccessing }
+STypeClassInfo >> classMethodsFor: aSpyClass [
+	| classMethods |
+	classMethods := OrderedCollection new.
+	(aSpyClass metaclassSpy typeName endsWith: ' class') ifTrue: [ 
+		classMethods := (aSpyClass metaclassSpy methods reject: #isTest) select:
+					[ :clsMethod | clsMethod wasExecuted and: [ clsMethod isValidReturnTypeWithReceiver ] ] 	].
+	^ classMethods 
 ]
 
 { #category : #copying }
@@ -190,6 +193,22 @@ STypeClassInfo >> initialize [
 	methodTypes := Dictionary new.
 	classMethodTypes := Dictionary new.
 	scalars := Dictionary new
+]
+
+{ #category : #accesing }
+STypeClassInfo >> instanceMethodsFor: aSpyClass [
+	| instanceMethods |
+	instanceMethods := OrderedCollection new.
+	(aSpyClass typeName endsWith: ' class') ifFalse: [ 
+		instanceMethods := (aSpyClass methods reject: #isTest)
+				select: [ :each | each wasExecuted or: [ each isUnary ]].
+		instanceMethods do: [ :each | each numberOfExecutions = 0 ifTrue: [
+			each numberOfExecutions: 0.5.
+			each returnValue: nil.
+			each saveReceiver: (each originalMethod origin)
+		]]
+	].
+	^ instanceMethods
 ]
 
 { #category : #actions }

--- a/src/SmallSuiteGenerator/STypeClassInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeClassInfo.class.st
@@ -214,8 +214,7 @@ STypeClassInfo >> instanceMethodsFor: aSpyClass [
 { #category : #actions }
 STypeClassInfo >> joinWith: otherTypeClass [
 	otherTypeClass methodTypes do: [ :aMethod | 
-		self addMethod: aMethod
-		 ].
+		self addMethod: aMethod ].
 	otherTypeClass classMethodTypes do: [ :aMethod | self addClassMethod: aMethod ]
 ]
 

--- a/src/SmallSuiteGenerator/STypeInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeInfo.class.st
@@ -62,6 +62,7 @@ STypeInfo >> addClassInfo: aTypeClassInfo [
 { #category : #converting }
 STypeInfo >> asTypeInfo: aTypeCollector [
 	| typeInfo |
+	self cleanBlockClosuresOf: aTypeCollector .
 	typeInfo := self class new.
 	aTypeCollector allClasses
 		do: [ :aSpyClass | 
@@ -74,6 +75,7 @@ STypeInfo >> asTypeInfo: aTypeCollector [
 { #category : #converting }
 STypeInfo >> asTypeInfo: aTypeCollector methodsBlacklist: aList [
 	| typeInfo |
+	self cleanBlockClosuresOf: aTypeCollector.
 	typeInfo := self class new.
 	aTypeCollector allClasses
 		do: [ :aSpyClass | 
@@ -116,6 +118,15 @@ STypeInfo >> classes [
 				at: aClassName
 				ifAbsentPut: (SPlatform lookUpClass: aClassName) ].
 	^ classes
+]
+
+{ #category : #converting }
+STypeInfo >> cleanBlockClosuresOf: aTypeCollector [ 
+	[ |cleanBlocks|
+		cleanBlocks := (aTypeCollector scalars at: #BlockClosure) select: [ :e | e isClean ].
+		aTypeCollector scalars at: #BlockClosure put: cleanBlocks ]
+	on: Error
+	do: [].
 ]
 
 { #category : #copying }

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -117,6 +117,7 @@ STypeMethodInfo >> copy [
 
 { #category : #actions }
 STypeMethodInfo >> copyValuesOf: otherTypeMethod [
+	(otherTypeMethod hasProfiler and: [ otherTypeMethod returnType types isNotEmpty ]) ifFalse: [^ self].
 	returnType := otherTypeMethod returnType.
 	argTypes := otherTypeMethod argTypes.
 	receiver := otherTypeMethod receiver.
@@ -418,7 +419,7 @@ STypeMethodInfo >> isWithReturnType: aClassName [
 
 { #category : #actions }
 STypeMethodInfo >> joinWith: otherTypeMethod [
-	hasProfiler ifFalse: [ otherTypeMethod hasProfiler ifTrue: [self copyValuesOf: otherTypeMethod ]]
+	hasProfiler ifFalse: [ self copyValuesOf: otherTypeMethod ]
 	ifTrue: [ 
 		argTypes ifNotNil: [argTypes
 			with: otherTypeMethod argTypes

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -122,7 +122,6 @@ STypeMethodInfo >> copyValuesOf: otherTypeMethod [
 	argTypes := otherTypeMethod argTypes.
 	receiver := otherTypeMethod receiver.
 	hasProfiler := otherTypeMethod hasProfiler.
-	executions := otherTypeMethod executions
 ]
 
 { #category : #accessing }

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -383,6 +383,11 @@ STypeMethodInfo >> isSimpleTyped9 [
 		allSatisfy: #yourself
 ]
 
+{ #category : #accessing }
+STypeMethodInfo >> isUnary [
+	^ selector isUnary 
+]
+
 { #category : #testing }
 STypeMethodInfo >> isWithReturnType: aClassName [
 	^ returnType types includes: aClassName

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -110,6 +110,7 @@ STypeMethodInfo >> copy [
 		returnType: returnType copy;
 		argTypes: argTypes copy;
 		scalars: scalars copy;
+		executions: executions;
 		receiver: receiver copy.
 	^ copy
 ]
@@ -119,7 +120,7 @@ STypeMethodInfo >> copyValuesOf: otherTypeMethod [
 	returnType := otherTypeMethod returnType.
 	argTypes := otherTypeMethod argTypes.
 	receiver := otherTypeMethod receiver.
-	hasProfiler := true.
+	hasProfiler := otherTypeMethod hasProfiler.
 	executions := otherTypeMethod executions
 ]
 
@@ -417,7 +418,7 @@ STypeMethodInfo >> isWithReturnType: aClassName [
 
 { #category : #actions }
 STypeMethodInfo >> joinWith: otherTypeMethod [
-	hasProfiler ifFalse: [ self copyValuesOf: otherTypeMethod ]
+	hasProfiler ifFalse: [ otherTypeMethod hasProfiler ifTrue: [self copyValuesOf: otherTypeMethod ]]
 	ifTrue: [ 
 		argTypes ifNotNil: [argTypes
 			with: otherTypeMethod argTypes

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -26,7 +26,7 @@ Class {
 	#category : #'SmallSuiteGenerator-Info'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 STypeMethodInfo class >> asMethodInfo: aSpyMethod [
 	^ self new asMethodInfo: aSpyMethod 
 ]
@@ -397,7 +397,7 @@ STypeMethodInfo >> isWithReturnType: aClassName [
 STypeMethodInfo >> joinWith: otherTypeMethod [
 	argTypes ifNotNil: [argTypes
 		with: otherTypeMethod argTypes
-		do: [ :argType :otherArgType | argType joinWith: otherArgType ].  ].
+		do: [ :argType :otherArgType | argType joinWith: otherArgType ] ].
 	
 	returnType joinWith: otherTypeMethod returnType
 ]

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -21,7 +21,8 @@ Class {
 		'isDeprecated',
 		'receiver',
 		'scalars',
-		'executions'
+		'executions',
+		'hasProfiler'
 	],
 	#category : #'SmallSuiteGenerator-Info'
 }
@@ -94,7 +95,8 @@ STypeMethodInfo >> asMethodInfo: typeCollMethod [
 		isQuick: typeCollMethod isQuick;
 		scalars: typeCollMethod dictLiterals;
 		isDeprecated: typeCollMethod isDeprecated;
-		executions: typeCollMethod numberOfExecutions 
+		executions: typeCollMethod numberOfExecutions;
+		hasProfiler: typeCollMethod wasExecuted 
 ]
 
 { #category : #copying }
@@ -110,6 +112,15 @@ STypeMethodInfo >> copy [
 		scalars: scalars copy;
 		receiver: receiver copy.
 	^ copy
+]
+
+{ #category : #actions }
+STypeMethodInfo >> copyValuesOf: otherTypeMethod [
+	returnType := otherTypeMethod returnType.
+	argTypes := otherTypeMethod argTypes.
+	receiver := otherTypeMethod receiver.
+	hasProfiler := true.
+	executions := otherTypeMethod executions
 ]
 
 { #category : #accessing }
@@ -136,6 +147,16 @@ STypeMethodInfo >> executions: anObject [
 	executions := anObject 
 ]
 
+{ #category : #accessing }
+STypeMethodInfo >> hasProfiler [
+	^ hasProfiler
+]
+
+{ #category : #accessing }
+STypeMethodInfo >> hasProfiler: aBoolean [
+	hasProfiler := aBoolean 
+]
+
 { #category : #comparing }
 STypeMethodInfo >> hash [
 	^ selector hash
@@ -149,7 +170,8 @@ STypeMethodInfo >> initialize [
 	returnType := SMultiTypeInfo new.
 	receiver := SMultiTypeInfo new.
 	isDeprecated := false.
-	scalars := Dictionary new
+	scalars := Dictionary new.
+	hasProfiler := true
 ]
 
 { #category : #accessing }
@@ -395,11 +417,13 @@ STypeMethodInfo >> isWithReturnType: aClassName [
 
 { #category : #actions }
 STypeMethodInfo >> joinWith: otherTypeMethod [
-	argTypes ifNotNil: [argTypes
-		with: otherTypeMethod argTypes
-		do: [ :argType :otherArgType | argType joinWith: otherArgType ] ].
-	
-	returnType joinWith: otherTypeMethod returnType
+	hasProfiler ifFalse: [ self copyValuesOf: otherTypeMethod ]
+	ifTrue: [ 
+		argTypes ifNotNil: [argTypes
+			with: otherTypeMethod argTypes
+			do: [ :argType :otherArgType | argType joinWith: otherArgType ] ].
+		returnType joinWith: otherTypeMethod returnType
+	]
 ]
 
 { #category : #accessing }

--- a/src/SmallSuiteGenerator/STypeMethodInfo.class.st
+++ b/src/SmallSuiteGenerator/STypeMethodInfo.class.st
@@ -84,7 +84,7 @@ STypeMethodInfo >> argTypes: anObject [
 	argTypes := anObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 STypeMethodInfo >> asMethodInfo: typeCollMethod [
 	^ self class new
 		selector: typeCollMethod selector;
@@ -126,12 +126,12 @@ STypeMethodInfo >> dataCSV [
 		add: returnType commonSuperclass; yourself)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #acccessing }
 STypeMethodInfo >> executions [
 	^ executions  
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #acccessing }
 STypeMethodInfo >> executions: anObject [
 	executions := anObject 
 ]
@@ -452,7 +452,7 @@ STypeMethodInfo >> transform: aSet [
 	^ multiType
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 STypeMethodInfo >> transformArgs: allArgs [
 	^ allArgs
 		collect: [ :args | 

--- a/src/SmallSuiteGenerator/SUndefinedObject.class.st
+++ b/src/SmallSuiteGenerator/SUndefinedObject.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #SUndefinedObject,
+	#superclass : #UndefinedObject,
+	#category : #'SmallSuiteGenerator-Info'
+}

--- a/src/SmallSuiteGenerator/SUndefinedObject.class.st
+++ b/src/SmallSuiteGenerator/SUndefinedObject.class.st
@@ -1,3 +1,6 @@
+"
+I'm a generic class for returnType of methods unexecuted
+"
 Class {
 	#name : #SUndefinedObject,
 	#superclass : #UndefinedObject,

--- a/src/SmallSuiteGenerator/SmallTypeCollector.class.st
+++ b/src/SmallSuiteGenerator/SmallTypeCollector.class.st
@@ -62,7 +62,7 @@ SmallTypeCollector >> methodInfoIn: aCompiledMethod from: tempTypes [
 			((types size = 1) and:[types first = Object]) ifTrue:[ "name type"
 					argType type: (self typeFor:argName).
 				] ifFalse:[
-					types do:[ :argClass | argType type: argClass name asSymbol. ].				
+					types do:[ :argClass | argClass isMeta ifFalse: [ argType type: argClass name asSymbol ] ].				
 				].
 			argTypes add: argType.
 		].

--- a/src/SmallSuiteGenerator/SmallTypeCollector.class.st
+++ b/src/SmallSuiteGenerator/SmallTypeCollector.class.st
@@ -1,0 +1,108 @@
+Class {
+	#name : #SmallTypeCollector,
+	#superclass : #Object,
+	#instVars : [
+		'classDict'
+	],
+	#category : #'SmallSuiteGenerator-SmallType'
+}
+
+{ #category : #action }
+SmallTypeCollector >> collectTypeFrom: aClass [
+	|collector extractor typeInfo methodInfo|
+	aClass isMeta ifTrue:[ ^ nil.].
+	collector := TypeCollector new.
+	collector onClass: aClass.
+	extractor := collector newExtractor.
+	aClass selectorsAndMethodsDo: [ :selector :method |
+		collector currentExtractedMethod: method. 
+			extractor
+				extractInterfacesFrom: method
+				addTo: collector].
+	typeInfo := STypeClassInfo newFrom: aClass name.
+	aClass methods do:[ :method | 
+			collector localTypingResults at: method ifPresent:[ :tmpTypes |
+				methodInfo := self methodInfoIn: method from: tmpTypes.
+				typeInfo addMethod: methodInfo.
+			]	
+		].
+	aClass class methods do:[ :method | 
+			collector localTypingResults at: method ifPresent:[ :tmpTypes |		
+				methodInfo := self methodInfoIn: method from: tmpTypes.
+				typeInfo addClassMethod: methodInfo.		
+			]
+		].
+	^ typeInfo.
+]
+
+{ #category : #initalize }
+SmallTypeCollector >> initialize [
+	super initialize.
+	classDict := Dictionary new.
+	Object withAllSubclasses do:[ :class|
+			classDict at: class name asLowercase put: class.
+		]
+]
+
+{ #category : #action }
+SmallTypeCollector >> methodInfoIn: aCompiledMethod from: tempTypes [
+	|methodTypeInfo argTypes returnType types|
+	methodTypeInfo := STypeMethodInfo new.
+	methodTypeInfo 
+		selector: aCompiledMethod selector;
+		isQuick: aCompiledMethod isQuick;
+		scalars: Dictionary new;
+		isDeprecated: aCompiledMethod isDeprecated;
+		executions: 0.
+	argTypes := OrderedCollection new.
+	aCompiledMethod ast argumentNames doWithIndex:[ :argName : index|
+			|argType|
+			argType := SMultiTypeInfo new.
+			types := (tempTypes at: index) types.
+			((types size = 1) and:[types first = Object]) ifTrue:[ "name type"
+					argType type: (self typeFor:argName).
+				] ifFalse:[
+					types do:[ :argClass | argType type: argClass name asSymbol. ].				
+				].
+			argTypes add: argType.
+		].
+	returnType := SMultiTypeInfo new.
+	types := tempTypes last types.
+	((types size =1) and:[ types first = Object]) ifFalse:[
+		types do:[ :argClass | returnType type: argClass name asSymbol. ].
+	]. "if not it is empty"
+	methodTypeInfo returnType: returnType.
+	methodTypeInfo argTypes: argTypes."
+	methodTypeInfo receiver: nil." "this may cause a bug somewhere"
+	^ methodTypeInfo.
+]
+
+{ #category : #action }
+SmallTypeCollector >> typeFor: argName [
+	|index lastPart|
+	(argName = 'arg') ifTrue:[^#nil.].
+	"Case 1:"
+	(classDict at: argName asLowercase ifPresent:[ :value | ^ value name asString]).
+	"Case 2:"
+	index := 1.	
+	[(index <= argName size) and:[ (argName at: index) isLowercase]] whileTrue:[ index := index + 1.].
+	lastPart := argName copyFrom: index to: argName size.
+	(classDict at: lastPart asLowercase ifPresent:[ :value | ^ value name asString]).
+	"Case 3:"
+	(argName asLowercase = 'spec') ifTrue:[^ #MetacelloAbstractVersionConstructor].
+	"Case 4:"
+	('.*(b|B)lock.*' asRegex matches: argName) ifTrue:[^#BlockClosure].
+	"Case 5:"
+	('.*(o|O)rderedCollection.*' asRegex matches: argName) ifTrue:[^#OrderedCollection].
+	('.*(a|A)rray.*' asRegex matches: argName) ifTrue:[^#Array].
+	('.*(d|D)ictionary.*' asRegex matches: argName) ifTrue:[^#Dictionary].
+	('.*(s|S)et.*' asRegex matches: argName) ifTrue:[^#Set ].
+	('.*(b|B)ag.*' asRegex matches: argName) ifTrue:[^#Bag].
+	('.*(c|C)ollection.*' asRegex matches: argName) ifTrue:[^#Collection].
+	('.*(s|S)tring.*' asRegex matches: argName) ifTrue:[^#String].
+	('.*(s|S)ymbol.*' asRegex matches: argName) ifTrue:[^#Symbol].
+	
+	^ #nil.	
+
+
+]

--- a/src/SmallSuiteGenerator/SmallTypeCollector.class.st
+++ b/src/SmallSuiteGenerator/SmallTypeCollector.class.st
@@ -72,8 +72,7 @@ SmallTypeCollector >> methodInfoIn: aCompiledMethod from: tempTypes [
 		types do:[ :argClass | returnType type: argClass name asSymbol. ].
 	]. "if not it is empty"
 	methodTypeInfo returnType: returnType.
-	methodTypeInfo argTypes: argTypes."
-	methodTypeInfo receiver: nil." "this may cause a bug somewhere"
+	methodTypeInfo argTypes: argTypes.
 	^ methodTypeInfo.
 ]
 
@@ -82,12 +81,12 @@ SmallTypeCollector >> typeFor: argName [
 	|index lastPart|
 	(argName = 'arg') ifTrue:[^#nil.].
 	"Case 1:"
-	(classDict at: argName asLowercase ifPresent:[ :value | ^ value name asString]).
+	(classDict at: argName asLowercase ifPresent:[ :value | ^ value name ]).
 	"Case 2:"
 	index := 1.	
 	[(index <= argName size) and:[ (argName at: index) isLowercase]] whileTrue:[ index := index + 1.].
 	lastPart := argName copyFrom: index to: argName size.
-	(classDict at: lastPart asLowercase ifPresent:[ :value | ^ value name asString]).
+	(classDict at: lastPart asLowercase ifPresent:[ :value | ^ value name ]).
 	"Case 3:"
 	(argName asLowercase = 'spec') ifTrue:[^ #MetacelloAbstractVersionConstructor].
 	"Case 4:"

--- a/src/SmallSuiteGenerator/TypeCollector.extension.st
+++ b/src/SmallSuiteGenerator/TypeCollector.extension.st
@@ -1,0 +1,75 @@
+Extension { #name : #TypeCollector }
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> collectorAfterTypeInstvarsOfClass: aClass [
+	"self typeInstvarsOfClass: Point"
+
+	^self new typeInstvarsOfClass: aClass; yourself
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector >> localTypingResults [
+	^ localTypingResults
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> new [
+	"Override new to return either a VWTypeCollector or a SqueakTypeCollector"
+
+	^self newForPlatform
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> newForPlatform [
+	"Return either a VWTypeCollector or a SqueakTypeCollector, depending on the platform used."
+
+	^PharoTypeCollector basicNew
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> onClass: aClass [
+	^self new onClass: aClass
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> typeInstvar: var ofClass: aClass [
+	"self typeInstvar: #x ofClass: Point "
+
+	^(self new typeInstvarsOfClass: aClass) at: var
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> typeInstvar: var ofClassWithLookup: aClass [ 
+	"self typeInstvar: #origin ofClassWithLookup: Quadrangle"
+	| theClass |
+	theClass := aClass.
+	[theClass isNil not
+		and: [theClass instVarNames includes: var]]
+		whileFalse: [theClass := theClass superclass].
+	theClass isNil
+		ifTrue: [^ ExtractedType new].
+	^ self typeInstvar: var ofClass: theClass
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> typeInstvarsOfClass: aClass [
+	"self typeInstvarsOfClass: Point"
+
+	^self new typeInstvarsOfClass: aClass
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> typeTmpsIn: aCompiledMethod ofClass: aClass [
+	"self typeInstvarsOfClass: Point"
+
+	^self new typeTmpsIn: aCompiledMethod ofClass: aClass
+]
+
+{ #category : #'*SmallSuiteGenerator' }
+TypeCollector class >> versionString [
+	"Take the removal of the standard version method on Smalltalk into account for Squeak :-( "
+
+	^(Smalltalk
+		at: #SystemVersion
+		ifAbsent: [^Smalltalk version]) current version
+]


### PR DESCRIPTION
- Clean blocks that not use external variables.
# Methods without TypeInfo
- Call methods without args
- Use SmallTypeCollector to find args types.
- Call methods with finded args (also using subclasses of type arg existing in typeInfo's scalars)